### PR TITLE
Changes from background agent bc-7f2c65e5-3d67-41fc-8476-726f6cf21ff8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 
 # Install CPU torch compatible with py3.9 and SB3==1.6.2
-RUN pip install --no-cache-dir --upgrade pip \
+RUN pip install --no-cache-dir "pip<24.1" \
   && pip install --no-cache-dir torch==1.11.0 torchvision==0.12.0 \
   && pip install --no-cache-dir -r /app/requirements.txt \
   && pip install --no-cache-dir mplfinance==0.12.10b0


### PR DESCRIPTION
Pin pip version to allow installation of `gym==0.21.0`.

Newer pip versions (24.1+) reject `gym==0.21.0` due to its legacy metadata format, causing the Docker build to fail. Pinning pip to a version below 24.1 resolves this compatibility issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f2c65e5-3d67-41fc-8476-726f6cf21ff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f2c65e5-3d67-41fc-8476-726f6cf21ff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

