### PR TITLE
Changes from background agent bc-ac92b679-7d9d-431b-a4e8-b002e6b06581

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 
-# Install CPU torch compatible with py3.9 and SB3==1.6.2
-RUN pip install --no-cache-dir "pip<24.1" \
+# Install CPU torch and pin build tools to support old gym packaging
+RUN pip install --no-cache-dir "pip<24.1" "setuptools==59.8.0" "wheel==0.38.4" "packaging==21.3" \
+  && (pip install --no-cache-dir --only-binary=:all: gym==0.21.0 || pip install --no-cache-dir gym==0.21.0) \
   && pip install --no-cache-dir torch==1.11.0 torchvision==0.12.0 \
   && pip install --no-cache-dir -r /app/requirements.txt \
   && pip install --no-cache-dir mplfinance==0.12.10b0


### PR DESCRIPTION
Pin build tools and pre-install `gym==0.21.0` to resolve a packaging metadata incompatibility.

The `gym==0.21.0` package's `setup.py` contains metadata that causes a `ParserSyntaxError` when processed by newer versions of `setuptools` and `wheel`. This PR pins these build tools to compatible older versions (`setuptools==59.8.0`, `wheel==0.38.4`, `packaging==21.3`) and attempts to install `gym` as a pre-built wheel first, ensuring a successful build.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac92b679-7d9d-431b-a4e8-b002e6b06581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac92b679-7d9d-431b-a4e8-b002e6b06581">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

